### PR TITLE
Fix: Correct startup commands and add Claude Desktop guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,50 @@ pip install -r requirements.txt
 
 ### Starting the Server
 
+There are a couple of ways to run the SaasToMCP server:
+
+**1. After installation (recommended):**
+
+If you have installed the package (e.g., using `pip install .` from the project root after installing requirements), you can use the command-line script:
+
 ```bash
-python saas_to_mcp.py
+saas-to-mcp run [OPTIONS]
 ```
+For example, to start with default settings:
+```bash
+saas-to-mcp run
+```
+To start with SSE transport (often useful for web-based tools like Claude Desktop):
+```bash
+saas-to-mcp run --transport sse --host 127.0.0.1 --port 8000
+```
+
+**2. Directly from the repository (for development):**
+
+If you are running the code directly from the cloned repository without installing the package:
+```bash
+# From the root of the repository
+python -m saas_to_mcp.cli run [OPTIONS]
+```
+Or:
+```bash
+python saas_to_mcp/cli.py run [OPTIONS]
+```
+Refer to `saas-to-mcp run --help` (or `python -m saas_to_mcp.cli run --help`) for available options.
 
 Or use with the MCP CLI:
 
-```bash
-mcp install saas_to_mcp.py
-```
+It's generally recommended to run SaasToMCP as a separate server process. However, if your MCP client supports direct installation of local Python scripts or packages as tools:
+
+- If SaasToMCP is installed in your Python environment, you might be able to register it using its package name (this depends on your MCP client's capabilities):
+  ```bash
+  mcp install saas-to-mcp 
+  ```
+- Or, you might point to the local `cli.py` file (path may need adjustment):
+  ```bash
+  mcp install path/to/your/SaasToMCP/saas_to_mcp/cli.py
+  ```
+Consult your MCP client's documentation for the correct way to add local tools. For most uses with AI assistants, running SaasToMCP as a standalone server (see above) and connecting to its SSE endpoint is the more common approach.
 
 ### Core Tools
 
@@ -44,6 +79,31 @@ The server provides these built-in tools:
 2. **list_apis** - List all registered APIs and their endpoints
 3. **unregister_api** - Remove an API and its tools
 4. **test_api_connection** - Test connectivity to a registered API
+
+### Using with AI Assistants (like Claude Desktop)
+
+SaasToMCP is designed to expose web APIs as tools for AI assistants that support the Model Context Protocol (MCP). Here's a general guide to using it with an assistant like Claude Desktop:
+
+1.  **Start the SaasToMCP Server:**
+    It's recommended to run SaasToMCP as a server with Server-Sent Events (SSE) transport, as this is commonly used for web-based AI tools.
+    ```bash
+    # After installing the package
+    saas-to-mcp run --transport sse --host 127.0.0.1 --port 8000
+    ```
+    This will start the server, and by default, the MCP endpoint will be available at `http://127.0.0.1:8000/mcp`. You can customize the host, port, and path using the command-line options.
+
+2.  **Configure Your AI Assistant (Claude Desktop):**
+    *   Open your Claude Desktop application or interface.
+    *   Look for a section related to "Tools," "Plugins," "Custom Tools," or "MCP Servers."
+    *   You'll likely need to add a new MCP tool provider or server by providing the URL of the SaasToMCP endpoint (e.g., `http://127.0.0.1:8000/mcp`).
+    *   **Note:** The exact steps for adding an MCP tool can vary depending on the version and specific interface of your Claude Desktop or other AI assistant. Please consult the documentation for your specific AI assistant for detailed instructions.
+
+3.  **Register APIs and Use Tools:**
+    *   Once Claude Desktop is connected to your SaasToMCP server, you can use the built-in `register_api` tool (usually by instructing the assistant) to define the web APIs you want to access. Provide the JSON configuration for the API you wish to integrate.
+    *   After an API is successfully registered, its endpoints will become available as new tools that the AI assistant can use. For example, if you register an API named `mynews` with an endpoint `get_latest_headlines`, a tool like `mynews_get_latest_headlines` should become available.
+    *   You can then instruct your AI assistant to use these tools (e.g., "Claude, use mynews_get_latest_headlines to find recent tech news").
+
+By following these steps, you can extend the capabilities of your AI assistant by giving it access to a wide range of web services through SaasToMCP.
 
 ### API Configuration Format
 
@@ -392,9 +452,13 @@ The server provides detailed error messages for:
 
 ### Debug Mode
 
-Run with verbose logging:
+Run with verbose logging (if installed):
 ```bash
-python saas_to_mcp.py --verbose
+saas-to-mcp run --verbose
+```
+Or from the repository:
+```bash
+python -m saas_to_mcp.cli run --verbose
 ```
 
 ## Contributing


### PR DESCRIPTION
I've updated the README.md to:
- Correct the server startup commands, providing instructions for both installed package execution (`saas-to-mcp run`) and direct repository execution (`python -m saas_to_mcp.cli run`).
- Clarify options for using with `mcp install`, recommending running as a separate server.
- Add a new section "Using with AI Assistants (like Claude Desktop)" explaining how to connect SaasToMCP to assistants like Claude Desktop, including starting the server in SSE mode and configuring the assistant.
- Update the "Debug Mode" command to reflect the new CLI structure.

These changes address the issue of incorrect/outdated commands and provide better guidance for you if you're wanting to integrate SaasToMCP with AI assistants.